### PR TITLE
chore: update DiscordUser types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,8 @@ export interface DiscordUser {
 	public_flags: number;
 	id: Snowflake;
 	discriminator: string;
+	bot: boolean;
+	avatar_decoration: string;
 	avatar: string;
 }
 


### PR DESCRIPTION
Adds `avatar_decoration` string (and `bot`, which I noticed was missing) to DiscordUser interface
https://github.com/discord/discord-api-docs/pull/5723/