### PR TITLE
feat: pomelo username types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,11 @@ export interface DiscordUser {
 	username: string;
 	public_flags: number;
 	id: Snowflake;
+	global_name: string;
+	/**
+	 * @deprecated Use global_name instead.
+	 */
+	display_name: string;
 	discriminator: string;
 	bot: boolean;
 	avatar_decoration: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,11 +68,11 @@ export interface DiscordUser {
 	username: string;
 	public_flags: number;
 	id: Snowflake;
-	global_name: string;
+	global_name: string | null;
 	/**
 	 * @deprecated Use global_name instead.
 	 */
-	display_name: string;
+	display_name: string | null;
 	discriminator: string;
 	bot: boolean;
 	avatar_decoration: string | null;


### PR DESCRIPTION
Add types for Pomelo usernames (the new unique usernames) and display names.
`display_name` is marked as deprecated in favor of `global_name`