### PR TITLE
Bump @prequist/lanyard to ^1.2.0 for active_on_discord_vr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "use-lanyard",
 	"author": "Alistair Smith <hi@alistair.sh>",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"type": "module",
 	"description": "React hook for Lanyard for tracking your Discord presence.",
 	"repository": "https://github.com/alii/use-lanyard",
@@ -37,7 +37,7 @@
 		"hook"
 	],
 	"dependencies": {
-		"@prequist/lanyard": "^1.0.1"
+		"@prequist/lanyard": "^1.2.0"
 	},
 	"devDependencies": {
 		"@types/react": "^18.2.32",


### PR DESCRIPTION
Pulls in the new `active_on_discord_vr` presence field (types are re-exported from `@prequist/lanyard`). Bumps version to 1.7.1.

Note: run `yarn install` to refresh `yarn.lock` once `@prequist/lanyard@1.2.0` is on npm.